### PR TITLE
add a warning to cli.prep, change PREDICT behavior

### DIFF
--- a/src/vak/cli/prep.py
+++ b/src/vak/cli/prep.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 from datetime import datetime
+import warnings
 
 import toml
 
@@ -98,6 +99,15 @@ def prep(toml_path):
         section = 'LEARNCURVE'
     elif 'PREDICT' in config_toml:
         section = 'PREDICT'
+        if cfg.prep.labelset is not None:
+            warnings.warn(
+                "config has a PREDICT section, but labelset option is specified in PREP section."
+                "This would cause an error because the dataframe.from_files section will attempt to "
+                f"check whether the files in the data_dir ({cfg.prep.data_dir}) have labels in "
+                "labelset, even though those files don't have annotation.\n"
+                "Setting labelset to None."
+            )
+            cfg.prep.labelset = None
     else:
         raise ValueError(
             'Did not find a section named TRAIN, LEARNCURVE, or PREDICT in config.ini file;'


### PR DESCRIPTION
when config specifies 'labelset' but config has a [PREDICT] section,
raises a warning and changes 'labelset' to None

because without this, dataframe.from_files will try to check whether
the annotations for each audio file have only labels from labelset,
but since there's no annotation for those files (we're trying to
predict the annotations, presumably), the annotation will be "None" and
this will result in an error