### PR TITLE
Add transforms util with get defaults func #111

### DIFF
--- a/src/vak/transforms/__init__.py
+++ b/src/vak/transforms/__init__.py
@@ -1,1 +1,2 @@
 from .transforms import *
+from .util import get_defaults

--- a/src/vak/transforms/functional.py
+++ b/src/vak/transforms/functional.py
@@ -1,4 +1,13 @@
 import numpy as np
+import torch
+
+__all__ = [
+    'pad_to_window',
+    'reshape_to_window',
+    'standardize_spect',
+    'to_floattensor',
+    'to_longtensor',
+]
 
 
 def standardize_spect(spect, mean_freqs, std_freqs, non_zero_std):
@@ -91,3 +100,54 @@ def reshape_to_window(spect, window_size):
     """
     spect_height, spect_width = spect.shape
     return spect.reshape((-1, spect_height, window_size))
+
+
+def to_floattensor(arr):
+    """convert Numpy array to torch.FloatTensor.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+
+    Returns
+    -------
+    float_tensor
+        with dtype 'float32'
+    """
+    return torch.from_numpy(arr).float()
+
+
+def to_longtensor(arr):
+    """convert Numpy array to torch.LongTensor.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+
+    Returns
+    -------
+    long_tensor : torch.Tensor
+        with dtype 'float64'
+    """
+    return torch.from_numpy(arr).long()
+
+
+def add_channel(input, channel_dim=0):
+    """add a channel dimension to a 2-dimensional tensor.
+    Transform that makes it easy to treat a spectrogram as an image,
+    by adding a dimension with a single 'channel', analogous to grayscale.
+    In this way the tensor can be fed to e.g. convolutional layers.
+
+    Parameters
+    ----------
+    input : torch.Tensor
+        with two dimensions (height, width).
+    channel_dim : int
+        dimension where "channel" is added.
+        Default is 0, which returns a tensor with dimensions (channel, height, width).
+    """
+    if input.dim() != 2:
+        raise ValueError(
+            f'input tensor should have two dimensions but input.dim() is {input.dim()}'
+        )
+    return torch.unsqueeze(input, dim=channel_dim)

--- a/src/vak/transforms/transforms.py
+++ b/src/vak/transforms/transforms.py
@@ -6,7 +6,12 @@ from ..util.validation import column_or_1d
 from . import functional as F
 
 __all__ = [
-    'StandardizeSpect', 'PadToWindow', 'ReshapeToWindow'
+    'AddChannel',
+    'PadToWindow',
+    'ReshapeToWindow',
+    'StandardizeSpect',
+    'ToFloatTensor',
+    'ToLongTensor'
 ]
 
 
@@ -209,3 +214,62 @@ class ReshapeToWindow:
 
     def __call__(self, spect):
         return F.reshape_to_window(spect, self.window_size)
+
+
+class ToFloatTensor:
+    """convert Numpy array to torch.FloatTensor.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+
+    Returns
+    -------
+    float_tensor
+        with dtype 'float32'
+    """
+    def __init__(self):
+        pass
+
+    def __call__(self, arr):
+        return F.to_floattensor(arr)
+
+
+class ToLongTensor:
+    """convert Numpy array to torch.LongTensor.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+
+    Returns
+    -------
+    long_tensor : torch.Tensor
+        with dtype 'float64'
+    """
+    def __init__(self):
+        pass
+
+    def __call__(self, arr):
+        return F.to_longtensor(arr)
+
+
+class AddChannel:
+    """add a channel dimension to a 2-dimensional tensor.
+    Transform that makes it easy to treat a spectrogram as an image,
+    by adding a dimension with a single 'channel', analogous to grayscale.
+    In this way the tensor can be fed to e.g. convolutional layers.
+
+    Parameters
+    ----------
+    input : torch.Tensor
+        with two dimensions (height, width).
+    channel_dim : int
+        dimension where "channel" is added.
+        Default is 0, which returns a tensor with dimensions (channel, height, width).
+    """
+    def __init__(self, channel_dim=0):
+        self.channel_dim = channel_dim
+
+    def __call__(self, input):
+        return F.add_channel(input, channel_dim=self.channel_dim)

--- a/src/vak/transforms/util.py
+++ b/src/vak/transforms/util.py
@@ -1,0 +1,65 @@
+import torchvision.transforms
+
+from . import transforms as vak_transforms
+
+
+def get_defaults(mode,
+                 spect_standardizer=None,
+                 window_size=None,
+                 return_crop_vec=False,
+                 ):
+    """get default transforms
+
+    Parameters
+    ----------
+    mode : str
+        one of {'train', 'predict'}. Determines set of transforms.
+    spect_standardizer : vak.transforms.StandardizeSpect
+        instance that has already been fit to dataset, using fit_df method.
+        Default is None, in which case no standardization transform is applied.
+
+    Returns
+    -------
+    transform, target_transform : callable
+        one or more vak transforms to be applied to inputs x and, during training, the target y.
+        If more than one transform, they are combined into an instance of torchvision.transforms.Compose.
+        Note that when mode is 'predict', the target transform is None.
+    """
+    # regardless of mode, transform always starts with StandardizeSpect, if used
+    if spect_standardizer is not None:
+        if isinstance(spect_standardizer, vak_transforms.StandardizeSpect):
+            transform = [spect_standardizer]
+        else:
+            raise TypeError(
+                f'invalid type for spect_standardizer: {type(spect_standardizer)}. '
+                'Should be an instance of vak.transforms.StandardizeSpect'
+            )
+    else:
+        transform = []
+
+    if mode == 'train':
+        transform.extend(
+            [
+                vak_transforms.ToFloatTensor(),
+                vak_transforms.AddChannel(),
+            ]
+        )
+
+        target_transform = vak_transforms.ToLongTensor()
+    elif mode == 'predict':
+        transform.extend(
+            [
+                vak_transforms.PadToWindow(window_size, return_crop_vec),
+                vak_transforms.ReshapeToWindow(window_size),
+                vak_transforms.ToFloatTensor(),
+                vak_transforms.AddChannel(channel_dim=1),  # add channel at first dimension because windows become batch
+            ]
+        )
+        target_transform = None
+    else:
+        raise ValueError(
+            f'invalid mode: {mode}'
+        )
+
+    transform = torchvision.transforms.Compose(transform)
+    return transform, target_transform


### PR DESCRIPTION
fixes #111 provisionally

I can get `vak train` to run with `normalize_spectrograms = false` when testing on cbin audio files and .not.mat annotations.

Since we don't have tests working right now, not clear whether I introduced any regressions -- need to separately test whether it works on predict as well.

Will go ahead and merge this in so I can fix #110 for @yardencsGitHub 