### PR TITLE
fix how `vak.Model` checks patience, #166

### DIFF
--- a/src/vak/engine/model.py
+++ b/src/vak/engine/model.py
@@ -389,9 +389,14 @@ class Model:
                         val_data,
                         val_step,
                         ckpt_step)
+            if patience is not None:
+                if self.patience_counter > self.patience:
+                    # need to break here too, not just inside _train function
+                    break
 
-        log_or_print('Completed last epoch.', logger=self.logger, level='info')
-        self.save(self.ckpt_path, epoch=epoch, global_step=self.global_step)
+        if epoch == num_epochs:  # save at end, if we complete all epochs (not if we stopped because of patience)
+            log_or_print('Completed last epoch.', logger=self.logger, level='info')
+            self.save(self.ckpt_path, epoch=epoch, global_step=self.global_step)
 
     def evaluate(self,
                  eval_data,


### PR DESCRIPTION
check not only in `_train` function after each
validation step, but also a level up in the
`fit` function after `_train` returns after
each epoch

fixes bug where training kept going even after
`patience_counter > patience` because `fit` would
just call `_train` again for the next epoch