### PR TITLE
fix variable name error in WindowDataset, fix #213

### DIFF
--- a/src/vak/datasets/window_dataset.py
+++ b/src/vak/datasets/window_dataset.py
@@ -309,7 +309,7 @@ class WindowDataset(VisionDataset):
                 return spect_id_vector[:cropped_length], spect_inds_vector[:cropped_length], x_inds
             else:
                 # try truncating from the back instead
-                lbl_tb_cropped = lbl_tb_cropped[-cropped_length:]
+                lbl_tb_cropped = lbl_tb[-cropped_length:]
                 if np.array_equal(np.unique(lbl_tb_cropped), classes):
                     x_inds[:-cropped_length] = WindowDataset.INVALID_WINDOW_VAL
                     return spect_id_vector[-cropped_length:], spect_inds_vector[-cropped_length:], x_inds


### PR DESCRIPTION
`lbl_tb_cropped` in line 312 should have been just `lbl_tb` --
this variable name error results in dataset duration
being cropped twice.

Changed to correct name.