### PR TITLE
Make sure x_inds points correctly after cropping

### DIFF
--- a/src/vak/datasets/window_dataset.py
+++ b/src/vak/datasets/window_dataset.py
@@ -311,7 +311,13 @@ class WindowDataset(VisionDataset):
                 # try truncating from the back instead
                 lbl_tb_cropped = lbl_tb[-cropped_length:]
                 if np.array_equal(np.unique(lbl_tb_cropped), classes):
+                    # set every index *up to but not including* the first valid window start to "invalid"
                     x_inds[:-cropped_length] = WindowDataset.INVALID_WINDOW_VAL
+                    # also need to 'reset' the indexing so it starts at 0. First find current minimum index value
+                    min_x_ind = x_inds[x_inds != WindowDataset.INVALID_WINDOW_VAL].min()
+                    # Then set min x ind to 0, min x ind + 1 to 1, min ind + 2 to 2, ...
+                    x_inds[x_inds != WindowDataset.INVALID_WINDOW_VAL] = \
+                        x_inds[x_inds != WindowDataset.INVALID_WINDOW_VAL] - min_x_ind
                     return spect_id_vector[-cropped_length:], spect_inds_vector[-cropped_length:], x_inds
                 else:
                     raise ValueError(


### PR DESCRIPTION
The vector x_inds points to bins in the training dataset where training windows can start.
When the voctors pointing to the data files and positions in them (spect_id_vector, spect_inds_vector) are cropped from their heads and line 488 throws those positions from x_inds it creates a situation where the entries of x_inds have an offset.

The change makes sure that there is no offset and the first bin in x_inds points to the first bin in the data pointing vectors (0) 