### PR TITLE
BUG: remove line from transforms.get_defaults, fix #211

### DIFF
--- a/src/vak/transforms/defaults.py
+++ b/src/vak/transforms/defaults.py
@@ -211,7 +211,6 @@ def get_defaults(mode,
 
         elif mode == 'predict':
             transform.extend([
-                spect_standardizer,
                 vak_transforms.PadToWindow(window_size, padval, return_padding_mask),
                 vak_transforms.ViewAsWindowBatch(window_size),
                 vak_transforms.ToFloatTensor(),


### PR DESCRIPTION
- `vak predict` crashes currently when no StandardizeSpect
  transform is used, because of line 214 in
  `vak.transforms.get_defaults` where, if the `mode` is
  `predict`, and `spect_standardizer' is `None`, the
  function adds that `None` to the list of transforms,
  and then tries to `compose` them
- simply removing the line that adds `spect_standardizer`
  to this list fixes the problem
- that's because in line 197, the function already instantiates
  a list with `spect_standardizer` if it is not `None`, or (if
  it is `None`), just instantiates an empty list