### PR TITLE
have Model._eval() cast metrics to numpy before divide, fix #249

### DIFF
--- a/src/vak/engine/model.py
+++ b/src/vak/engine/model.py
@@ -272,7 +272,7 @@ class Model:
         for metric_name in list(metric_vals):
             if metric_name in ['loss', 'acc', 'levenshtein', 'segment_error_rate']:
                 avg_metric_val = (
-                        torch.tensor(metric_vals[metric_name]).sum() / n_batches
+                        torch.tensor(metric_vals[metric_name]).sum().cpu().numpy() / n_batches
                 ).item()
                 metric_vals[f'avg_{metric_name}'] = avg_metric_val
             else:


### PR DESCRIPTION
change line in Model._eval() that sums metric values across batch
and then divides by batch size so that it converts the sum in a
tensor to a numpy array, to avoid RuntimeError because of
dividing a tensor by an integer (the batch size)