### PR TITLE
Remove sections param fix #200

### DIFF
--- a/src/vak/cli/prep.py
+++ b/src/vak/cli/prep.py
@@ -50,7 +50,7 @@ def prep(toml_path):
     will be 'predict' or 'test' (respectively).
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path, sections=['PREP', 'SPECTROGRAM', 'DATALOADER'])
+    cfg = config.parse.from_toml(toml_path)
 
     if cfg.prep is None:
         raise ValueError(

--- a/src/vak/config/parse.py
+++ b/src/vak/config/parse.py
@@ -58,18 +58,13 @@ SECTION_PARSERS = {
 }
 
 
-def from_toml(toml_path, sections=None):
+def from_toml(toml_path):
     """parse a TOML configuration file
 
     Parameters
     ----------
     toml_path : str, Path
         path to a configuration file in TOML format
-    sections : list
-        of str, names of sections from config.toml file to parse.
-        Default is None, in which case function attempts to parse all sections.
-        Used by vak.cli.prep to avoid throwing a bunch of errors if paths in
-        other sections don't exist yet.
 
     Returns
     -------
@@ -107,10 +102,8 @@ def from_toml(toml_path, sections=None):
                     "Were you trying to use the 'learncurve' command instead?"
                 )
 
-    if sections is None:
-        sections = list(SECTION_PARSERS.keys())
     config_dict = {}
-    for section_name in sections:
+    for section_name in SECTION_PARSERS.keys():
         if section_name in config_toml:
             are_options_valid(config_toml, section_name, toml_path)
             section_parser = SECTION_PARSERS[section_name]


### PR DESCRIPTION
fixes bug where `vak.config.parse` fails silently when passed a list of `sections` that are not in the config file.

e.g. passing the old name for the spectrogram parameters section, `[SPECTROGRAM]`, instead of the current name `[SPECT_PARAMS]`, silently ignores the actual section and instead just returns the default spectrogram parameters.

This bug became obvious after noticing that any spectrogram parameters besides the defaults were not being parsed. This is because internally the `vak.cli.prep` function was passing a list with `SPECTROGRAM` in it to `vak.config.parse` instead of `SPECT_PARAMS`, as just described.

- removes 'sections' parameter from function `vak.config.parse`
- removes the argument for that parameter that was passed in when `vak.cli.prep` called `vak.config.parse`