### PR TITLE
revise installation.rst, fix #265

### DIFF
--- a/doc/get_started/installation.rst
+++ b/doc/get_started/installation.rst
@@ -3,52 +3,68 @@
 Installation
 ============
 
-with ``conda`` environment and package manager
-----------------------------------------------
+Prerequisites: ``conda`` environment and package manager
+--------------------------------------------------------
 
-Currently, installing ``vak`` requires use of the ``conda`` tool to create a virtual environment and
-install the libraries that ``vak`` depends on into that environment. The easiest way to use ``conda`` is to install the
+``vak`` depends on several widely-used libraries from the Python data science ecosystem.
+Currently, the easiest way to install these libraries across operating systems
+(Linux, Mac, and Windows) is to use the ``conda`` tool.
+It will help you create what is a called a "virtual environment",
+and then install the libraries that ``vak`` depends on into that environment.
+The easiest way to use ``conda`` is to install the
 Anaconda platform (https://www.anaconda.com/download) (which is free).
 For a more detailed explanation of why you would use a virtual environment, please see
 :ref:`why-virtualenv`.
 
-Here are the steps to follow after installing Anaconda:
+Creating a virtual environment
+------------------------------
 
-.. code-block:: console
+Here are the steps to create a virtual environment after installing Anaconda.
+You should execute these in a terminal by entering the following commands at the prompt
+(indicated by the ``$`` below):
 
-    you@your-computer: ~/Documents $ conda create -n vak-env python=3.6
-    you@your-computer: ~/Documents $ source activate vak-env
+  * Create a virtual environment for ``vak``:
 
-(You don't have to ``source`` on Windows: ``> activate vak-env``)
+    .. code-block:: console
 
-Once you create and activate the environment, you can install ``vak``:
+        (base) you@your-computer: ~/Documents $ conda create -n vak-env python=3.6
+        (base) you@your-computer: ~/Documents $ conda activate vak-env
+        (vak-env) you@your-computer: ~/Documents $
 
-.. code-block:: console
+    There's no command in the last line above. It's there simply to show how the prompt changes
+    when you activate the environment. The name in parentheses indicates which environment is activated.
 
-    (vak-env) you@your-computer: ~/Documents $ conda install vak -c nickledave
+  * Install the dependencies using ``conda`` (not ``pip``, because this can cause issues on some platforms)
 
-Eventually ``vak`` will be available through the conda-forge channel.
-Keep an eye on this issue on GitHub:
+    .. code-block:: console
 
-| https://github.com/NickleDave/vak/issues/70
+        (vak-env) you@your-computer: ~/Documents $ conda install pytorch torchvision cudatoolkit -c pytorch
+        (vak-env) you@your-computer: ~/Documents $ conda install attrs dask joblib matplotlib pandas scipy toml tqdm
 
-with ``pip`` package manager
---------------------------------------------
+Once you have created the virtual environment, activated it, and installed the necessary dependencies,
+you can install ``vak``.
 
-We strongly suggest using ``conda`` to install, but you can also use ``pip``.
-Again we recommend installing into a ``conda`` environment:
+Installation with ``pip`` package manager
+-----------------------------------------
+
+You can use the Python package manager ``pip`` to install ``vak`` into the ``conda`` virtual environment
+you created.
 
 .. code-block:: console
 
     (vak-env)/home/you/code/ $ pip install vak
 
-Note that if you use ``pip``, and you are using a GPU, you will need to ensure that the
-installation of ``PyTorch`` is using the system install of binaries that it depends on, such as ``libcuda.so``.
+The main reason we use ``conda`` to install other dependencies, instead of letting ``pip`` handle that,
+is because ``conda`` makes it easier to work with GPUs.
+For example, using ``conda`` avoids the need to install and configure drivers for NVIDIA.
+In contrast, if you install just with ``pip``, and you are using a GPU,
+you may need to ensure that the installation of ``PyTorch`` is using the system install of binaries
+that it depends on, such as ``libcuda.so``.
 ``conda`` makes it possible to install ``cudatoolkit`` and other dependencies into a virtual environment
 to avoid dealing with system-wide installs of binaries.
 
-from source, e.g. for development
----------------------------------
+Installation from source, e.g. for development
+----------------------------------------------
 You can also work with a local copy of the code.
 It's possible to install the local copy with ``pip`` so that you can still edit
 the code, and then have its behavior as an installed library reflect those edits.
@@ -57,6 +73,15 @@ When working with ``vak`` this way, you'll most likely still want to isolate
 it within a virtual environment using ``conda``.
 
 Here's the steps to set up a development environment:
+  * Create a virtual environment for ``vak`` with the necessary dependencies (if you haven't already):
+
+    .. code-block:: console
+
+        you@your-computer: ~/Documents $ conda create -n vak-env python=3.6
+        you@your-computer: ~/Documents $ conda activate vak-env
+        (vak-env) you@your-computer: ~/Documents $ conda install pytorch torchvision cudatoolkit -c pytorch
+        (vak-env) you@your-computer: ~/Documents $ conda install attrs dask joblib matplotlib pandas scipy toml tqdm
+
   * Clone the repo from Github using the version control tool ``git``:
 
     .. code-block:: console
@@ -66,37 +91,29 @@ Here's the steps to set up a development environment:
     (you can install ``git`` from `Github <https://help.github.com/en/github/getting-started-with-github/set-up-git>`_,
     with your operating system package manager, or using ``conda``.)
 
-  * Create a virtual environment for ``vak``:
-
-    .. code-block:: console
-
-        you@your-computer: ~/Documents $ conda create -n vak-env python=3.6
-        you@your-computer: ~/Documents $ source activate vak-env
-        (vak-env) you@your-computer: ~/Documents $
-
-  * Install the dependencies using ``conda`` (not ``pip``, because this can cause issues on some platforms)
-
-    .. code-block:: console
-
-        (vak-env) you@your-computer: ~/Documents $ conda install pytorch torchvision cudatoolkit -c pytorch
-        (vak-env) you@your-computer: ~/Documents $ conda install attrs dask joblib matplotlib pandas scipy toml tqdm
-
-  * Install the package with `pip` using the `-e` flag (for ``editable``).
+  * In the root of the ``vak`` directory cloned by ``git``, use ``pip`` to install the package,
+    making the install ``editable`` with the ``-e`` option.
 
     .. code-block:: console
 
         (vak-env) you@your-computer: ~/Documents $ cd vak
         (vak-env) you@your-computer: ~/Documents/vak $ pip install -e .
 
-    * Note this will install some other dependencies from ``pip`` -- that's okay.
+    Note that ``pip`` may install some other dependencies for development -- that's okay.
+
+Eventually ``vak`` will be available through the conda-forge channel,
+meaning you can install with a single command into a ``conda`` environment.
+Keep an eye on this issue on GitHub:
+
+| https://github.com/NickleDave/vak/issues/70
 
 .. _why-virtualenv:
 
 Why use a virtual environment?
 ------------------------------
-Virtual environments makes it possible to install the things that
-the program you are using depend on, AKA "dependencies", in a way
-where they can be isolated from the dependencies of other programs.
+Virtual environments makes it possible to install the software libraries that
+a program depends on, known as "dependencies", so that
+they can be isolated from the dependencies of other programs.
 This avoids many issues, like when two programs depend on two
 different versions of the same library.
 For an in-depth explanation of virtual environments, please see
@@ -105,7 +122,7 @@ https://realpython.com/python-virtual-environments-a-primer/.
 Many libraries for data science packages have dependencies
 written in languages besides Python. There are platforms
 dedicated to managing these dependencies that you may find it easier to use.
-For example, Anaconda(https://www.anaconda.com/download) (which is free).
+For example, Anaconda (https://www.anaconda.com/download) (which is free).
 You can use the ``conda`` command-line tool that they develop
 to create environments and install the libraries that this package
 depends on. Here is an in-depth look at using `conda` to manage environments:


### PR DESCRIPTION
- remove instruction to install with `conda` from
  Anaconda cloud channel `nickledave`, because that
  version is broken (it's the 0.2.0 version)
- revise the rest of the page as follows
  * change section about virtual environments and `conda`
    into a "prerequisites section"
  * now have two types of installs, installing
    off of PyPI with `pip` after installing
    all other dependencies with `conda`, or
    a development install using the source code
    (still with `pip` but here it's `editable`)