### PR TITLE
Refactor results path

### DIFF
--- a/src/vak/cli/learncurve.py
+++ b/src/vak/cli/learncurve.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 import shutil
-from datetime import datetime
 
 from .. import config
 from .. import core
 from .. import logging
+from ..paths import generate_results_dir_name_as_path
+from ..timenow import get_timenow_as_str
 
 
 def learning_curve(toml_path):
@@ -33,13 +34,7 @@ def learning_curve(toml_path):
         )
 
     # ---- set up directory to save output -----------------------------------------------------------------------------
-    timenow = datetime.now().strftime('%y%m%d_%H%M%S')
-    results_dirname = f'results_{timenow}'
-    if cfg.learncurve.root_results_dir:
-        results_path = Path(cfg.learncurve.root_results_dir)
-    else:
-        results_path = Path('.')
-    results_path = results_path.joinpath(results_dirname)
+    results_path = generate_results_dir_name_as_path(cfg.learncurve.root_results_dir)
     results_path.mkdir(parents=True)
     # copy config file into results dir now that we've made the dir
     shutil.copy(toml_path, results_path)
@@ -47,7 +42,7 @@ def learning_curve(toml_path):
     # ---- set up logging ----------------------------------------------------------------------------------------------
     logger = logging.get_logger(log_dst=results_path,
                                 caller='train',
-                                timestamp=timenow,
+                                timestamp=get_timenow_as_str(),
                                 logger_name=__name__)
     logger.info('Logging results to {}'.format(results_path))
 

--- a/src/vak/cli/train.py
+++ b/src/vak/cli/train.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 import shutil
-from datetime import datetime
 
 from .. import config
 from .. import core
 from .. import logging
+from ..paths import generate_results_dir_name_as_path
+from ..timenow import get_timenow_as_str
 
 
 def train(toml_path):
@@ -32,13 +33,7 @@ def train(toml_path):
         )
 
     # ---- set up directory to save output -----------------------------------------------------------------------------
-    timenow = datetime.now().strftime('%y%m%d_%H%M%S')
-    results_dirname = f'results_{timenow}'
-    if cfg.train.root_results_dir:
-        results_path = Path(cfg.train.root_results_dir)
-    else:
-        results_path = Path('.')
-    results_path = results_path.joinpath(results_dirname)
+    results_path = generate_results_dir_name_as_path(cfg.train.root_results_dir)
     results_path.mkdir(parents=True)
     # copy config file into results dir now that we've made the dir
     shutil.copy(toml_path, results_path)
@@ -46,7 +41,7 @@ def train(toml_path):
     # ---- set up logging ----------------------------------------------------------------------------------------------
     logger = logging.get_logger(log_dst=results_path,
                                 caller='train',
-                                timestamp=timenow,
+                                timestamp=get_timenow_as_str(),
                                 logger_name=__name__)
     logger.info('Logging results to {}'.format(results_path))
 

--- a/src/vak/constants.py
+++ b/src/vak/constants.py
@@ -27,3 +27,6 @@ VALID_SPECT_FORMATS = list(SPECT_FORMAT_LOAD_FUNCTION_MAP.keys())
 # ---- annotation files ----
 VALID_ANNOT_FORMATS = crowsetta.formats._INSTALLED
 NO_ANNOTATION_FORMAT = 'none'
+
+# format for timestamps
+STRFTIME_TIMESTAMP = '%y%m%d_%H%M%S'

--- a/src/vak/constants.py
+++ b/src/vak/constants.py
@@ -30,3 +30,6 @@ NO_ANNOTATION_FORMAT = 'none'
 
 # format for timestamps
 STRFTIME_TIMESTAMP = '%y%m%d_%H%M%S'
+
+# ---- results, from train / learncurve ----
+RESULTS_DIR_PREFIX = 'results_'

--- a/src/vak/core/learncurve.py
+++ b/src/vak/core/learncurve.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
 from pprint import pprint
 import re
@@ -17,6 +16,7 @@ from .. import split
 from ..converters import expanded_user_path
 from ..datasets.window_dataset import WindowDataset
 from ..logging import log_or_print
+from ..paths import generate_results_dir_name_as_path
 
 
 # pattern used by path.glob to find all training data subset csvs within previous_run_path
@@ -395,17 +395,7 @@ def learning_curve(model_config_map,
                 f'results_path not recognized as a directory: {results_path}'
             )
     else:
-        if root_results_dir:
-            root_results_dir = Path(root_results_dir)
-        else:
-            root_results_dir = Path('.')
-        if not root_results_dir.is_dir():
-            raise NotADirectoryError(
-                f'root_results_dir not recognized as a directory: {root_results_dir}'
-            )
-        timenow = datetime.now().strftime('%y%m%d_%H%M%S')
-        results_dirname = f'results_{timenow}'
-        results_path = root_results_dir.joinpath(results_dirname)
+        results_path = generate_results_dir_name_as_path(root_results_dir)
         results_path.mkdir()
 
     log_or_print(

--- a/src/vak/core/train.py
+++ b/src/vak/core/train.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 from pathlib import Path
 
@@ -16,6 +15,7 @@ from ..datasets.vocal_dataset import VocalDataset
 from ..device import get_default as get_default_device
 from ..io import dataframe
 from ..logging import log_or_print
+from ..paths import generate_results_dir_name_as_path
 
 
 def train(model_config_map,
@@ -147,17 +147,7 @@ def train(model_config_map,
                 f'results_path not recognized as a directory: {results_path}'
             )
     else:
-        if root_results_dir:
-            root_results_dir = Path(root_results_dir)
-        else:
-            root_results_dir = Path('.')
-        if not root_results_dir.is_dir():
-            raise NotADirectoryError(
-                f'root_results_dir not recognized as a directory: {root_results_dir}'
-            )
-        timenow = datetime.now().strftime('%y%m%d_%H%M%S')
-        results_dirname = f'results_{timenow}'
-        results_path = root_results_dir.joinpath(results_dirname)
+        results_path = generate_results_dir_name_as_path(root_results_dir)
         results_path.mkdir()
 
     timebin_dur = dataframe.validate_and_get_timebin_dur(dataset_df)

--- a/src/vak/paths.py
+++ b/src/vak/paths.py
@@ -1,0 +1,37 @@
+"""functions for working with paths"""
+from pathlib import Path
+
+from . import constants, timenow
+
+
+def generate_results_dir_name_as_path(root_results_dir=None):
+    """generates a name for a new results directory,
+    returns as a path
+
+    Parameters
+    ----------
+    root_results_dir : str, pathlib.Path
+        root directory within which a new results directory will be made.
+        Default is None, in which case the new results directory name
+        will be relative to the current working directory.
+
+    Returns
+    -------
+    results_path : pathlib.Path
+        path to a new results directory, with name of the following format:
+        ``f'{vak.constants.RESULTS_DIR_PREFIX}{vak.timenow.get_timenow_as_str}'``.
+        e.g., ``results_210211_142329``.
+        This function simply builds the name and path with a consistent format.
+        To actually make this directory, call ``results_path.mkdir()``
+    """
+    if root_results_dir:
+        root_results_dir = Path(root_results_dir)
+    else:
+        root_results_dir = Path('.')
+    if not root_results_dir.is_dir():
+        raise NotADirectoryError(
+            f'root_results_dir not recognized as a directory: {root_results_dir}'
+        )
+
+    results_dirname = f'{constants.RESULTS_DIR_PREFIX}{timenow.get_timenow_as_str()}'
+    return root_results_dir.joinpath(results_dirname)

--- a/src/vak/timenow.py
+++ b/src/vak/timenow.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+from .constants import STRFTIME_TIMESTAMP
+
+
+def get_timenow_as_str():
+    f"""returns current time as a string, 
+    with the format specified by ``vak.constants.STRFTIME_TIMESTAMP``"""
+    return datetime.now().strftime(STRFTIME_TIMESTAMP)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+import os
+import time
+
+import pytest
+
+import vak.constants
+import vak.paths
+
+
+def results_path_matches_expected(results_path,
+                                  root_results_dir,
+                                  before_timestamp,
+                                  after_timestamp):
+    assert results_path.parents == root_results_dir
+    assert results_path.name.startswith(vak.constants.RESULTS_DIR_PREFIX)
+    results_dirname_parts = results_path.name.split(sep='_')
+    assert len(results_dirname_parts) == 2
+    timenow_str = results_dirname_parts[1]
+    assert len(timenow_str) == vak.constants.STRFTIME_TIMESTAMP
+    timenow_str_as_timestamp = time.mktime(
+        datetime.strptime(timenow_str, vak.constants.STRFTIME_TIMESTAMP).timetuple()
+    )
+    assert before_timestamp <= timenow_str_as_timestamp <= after_timestamp
+
+
+def test_generate_results_dir_name_as_path(tmp_path):
+    before_timestamp = time.mktime(datetime.now())
+    results_path = vak.paths.generate_results_dir_name_as_path(root_results_dir=tmp_path)
+    after_timestamp = time.mktime(datetime.now())
+
+    assert results_path_matches_expected(results_path,
+                                         root_results_dir=tmp_path,
+                                         before_timestamp=before_timestamp,
+                                         after_timestamp=after_timestamp)
+
+
+def test_generate_results_dir_name_as_path_no_root_results_dir(tmp_path):
+    before_timestamp = time.mktime(datetime.now())
+    os.chdir(tmp_path)
+    results_path = vak.paths.generate_results_dir_name_as_path(root_results_dir=None)
+    after_timestamp = time.mktime(datetime.now())
+
+    assert results_path_matches_expected(results_path,
+                                         root_results_dir=tmp_path,
+                                         before_timestamp=before_timestamp,
+                                         after_timestamp=after_timestamp)
+
+
+def test_generate_results_dir_name_as_path_nonexistent_root_raises():
+    with pytest.raises(NotADirectoryError):
+        vak.paths.generate_results_dir_name_as_path(root_results_dir='/obviously/not/an/existent/directory')

--- a/tests/unit/test_timenow.py
+++ b/tests/unit/test_timenow.py
@@ -1,0 +1,16 @@
+import time
+from datetime import datetime
+
+import vak.constants
+import vak.timenow
+
+
+def test_timenow():
+    before_timestamp = time.mktime(datetime.now())
+    timenow_str = vak.timenow.get_timenow_as_str()
+    assert len(timenow_str) == len(vak.constants.STRFTIME_TIMESTAMP)
+    timenow_str_as_timestamp = time.mktime(
+        datetime.strptime(timenow_str, vak.constants.STRFTIME_TIMESTAMP).timetuple()
+    )
+    after_timestamp = time.mktime(datetime.now())
+    assert before_timestamp <= timenow_str_as_timestamp <= after_timestamp


### PR DESCRIPTION
refactor how `results_path` is computed in `core` and `cli` functions for `train` and `learncurve`.
Previously the same code was repeated in all four functions.

This refactors that code into two helper functions, enforcing consistency and obeying "Don't Repeat Yourself".
Those helper functions also use constants declared in `vak.constants`.

This makes it easier to test they behave as expected, and makes it possible for other unit tests to cleanly 
test that expected results were generated, i.e., unit tests for `vak.core.train`, `vak.core.learncurve`, etc.

* adds two modules:
  + `vak.paths`, with function `generate_results_dir_name_as_path`, and
  + `vak.timenow`, with function `get_timenow_as_str`
* adds constant to `vak.constants`, `STRFTIME_TIMESTAMP` and `RESULTS_DIR_PREFIX`, that are used by those functions and are / will be used by unit tests