### PR TITLE
Refactor parse from toml

### DIFF
--- a/src/vak/cli/eval.py
+++ b/src/vak/cli/eval.py
@@ -20,7 +20,7 @@ def eval(toml_path):
     None
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path)
+    cfg = config.parse.from_toml_path(toml_path)
 
     if cfg.eval is None:
         raise ValueError(

--- a/src/vak/cli/learncurve.py
+++ b/src/vak/cli/learncurve.py
@@ -26,7 +26,7 @@ def learning_curve(toml_path):
     in config.toml file, and adds path to that new directory to config.toml file.
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path)
+    cfg = config.parse.from_toml_path(toml_path)
 
     if cfg.learncurve is None:
         raise ValueError(

--- a/src/vak/cli/predict.py
+++ b/src/vak/cli/predict.py
@@ -20,7 +20,7 @@ def predict(toml_path):
     None
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path)
+    cfg = config.parse.from_toml_path(toml_path)
 
     if cfg.predict is None:
         raise ValueError(

--- a/src/vak/cli/prep.py
+++ b/src/vak/cli/prep.py
@@ -50,7 +50,7 @@ def prep(toml_path):
     will be 'predict' or 'test' (respectively).
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path)
+    cfg = config.parse.from_toml_path(toml_path)
 
     if cfg.prep is None:
         raise ValueError(

--- a/src/vak/cli/train.py
+++ b/src/vak/cli/train.py
@@ -25,7 +25,7 @@ def train(toml_path):
     in config.toml file, and adds path to that new directory to config.toml file.
     """
     toml_path = Path(toml_path)
-    cfg = config.parse.from_toml(toml_path)
+    cfg = config.parse.from_toml_path(toml_path)
 
     if cfg.train is None:
         raise ValueError(

--- a/src/vak/config/dataloader.py
+++ b/src/vak/config/dataloader.py
@@ -17,7 +17,8 @@ class DataLoaderConfig:
                           default=88)
 
 
-def parse_dataloader_config(config_toml, toml_path):
+def parse_dataloader_config(config_toml,
+                            toml_path=None):
     """parse [DATALOADER] section of config.toml file
 
     Parameters
@@ -30,7 +31,7 @@ def parse_dataloader_config(config_toml, toml_path):
         for consistency with other functions.
         **Removing it will cause ``vak.config.parse.from_toml`` to crash, since it
         tries to loop through all the section parser functions,
-        nd pass them both arguments.**
+        and pass them both arguments.**
 
     Returns
     -------

--- a/src/vak/config/eval.py
+++ b/src/vak/config/eval.py
@@ -74,15 +74,16 @@ REQUIRED_EVAL_OPTIONS = [
 ]
 
 
-def parse_eval_config(config_obj, config_path):
+def parse_eval_config(config_toml, toml_path=None):
     """parse [EVAL] section of config.toml file
 
     Parameters
     ----------
-    config_obj : ConfigParser
+    config_toml : dict
         containing config.toml file already loaded by parse function
-    config_path : str
-        path to config.toml file (used for error messages)
+    toml_path : str
+        path to a configuration file in TOML format. Default is None.
+        Used for error messages if specified.
 
     Returns
     -------
@@ -91,13 +92,20 @@ def parse_eval_config(config_obj, config_path):
         of config.toml file
     """
     eval_section = dict(
-        config_obj['EVAL'].items()
+        config_toml['EVAL'].items()
     )
 
     for required_option in REQUIRED_EVAL_OPTIONS:
         if required_option not in eval_section:
-            raise KeyError(
-                f"the '{required_option}' option is required but was not found in the "
-                f"EVAL section of the config.toml file: {config_path}"
-            )
+            if toml_path:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"EVAL section of the config.toml file: {toml_path}"
+                )
+            else:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"EVAL section of the toml config"
+                )
+            raise KeyError(err_msg)
     return EvalConfig(**eval_section)

--- a/src/vak/config/learncurve.py
+++ b/src/vak/config/learncurve.py
@@ -73,7 +73,8 @@ def parse_learncurve_config(config_toml, toml_path):
     config_toml : dict
         containing configuration file in TOML format, already loaded by parse function
     toml_path : Path
-        path to a configuration file in TOML format (used for error messages)
+        path to a configuration file in TOML format. Default is None.
+        Used for error messages if specified.
 
     Returns
     -------
@@ -84,9 +85,16 @@ def parse_learncurve_config(config_toml, toml_path):
     learncurve_section = dict(learncurve_section.items())
     for required_option in REQUIRED_LEARNCURVE_OPTIONS:
         if required_option not in learncurve_section:
-            raise KeyError(
-                f"the '{required_option}' option is required but was not found in the "
-                f"LEARNCURVE section of the config.toml file: {toml_path}"
-            )
+            if toml_path:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"LEARNCURVE section of the config.toml file: {toml_path}"
+                )
+            else:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"LEARNCURVE section of the toml config"
+                )
+            raise KeyError(err_msg)
 
     return LearncurveConfig(**learncurve_section)

--- a/src/vak/config/parse.py
+++ b/src/vak/config/parse.py
@@ -58,13 +58,18 @@ SECTION_PARSERS = {
 }
 
 
-def from_toml(toml_path):
-    """parse a TOML configuration file
+def from_toml(config_toml,
+              toml_path=None):
+    """load a TOML configuration file
 
     Parameters
     ----------
+    config_toml : dict
+        Python ``dict`` containing a .toml configuration file,
+        parsed by the ``toml`` library.
     toml_path : str, Path
-        path to a configuration file in TOML format
+        path to a configuration file in TOML format. Default is None.
+        Not required, used only to make any error messages clearer.
 
     Returns
     -------
@@ -72,18 +77,6 @@ def from_toml(toml_path):
         instance of Config class, whose attributes correspond to
         sections in a config.toml file.
     """
-    # check config_path is a file,
-    # because if it doesn't ConfigParser will just return an "empty" instance w/out sections or options
-    toml_path = Path(toml_path)
-    if not toml_path.is_file():
-        raise FileNotFoundError(f'path not recognized as a file: {toml_path}')
-
-    try:
-        with toml_path.open('r') as fp:
-            config_toml = toml.load(fp)
-    except TomlDecodeError as e:
-        raise Exception(f'Error when parsing .toml config file: {toml_path}') from e
-
     are_sections_valid(config_toml, toml_path)
 
     if 'TRAIN' in config_toml:
@@ -110,3 +103,35 @@ def from_toml(toml_path):
             config_dict[section_name.lower()] = section_parser(config_toml, toml_path)
 
     return Config(**config_dict)
+
+
+def from_toml_path(toml_path):
+    """parse a TOML configuration file
+
+    Parameters
+    ----------
+    toml_path : str, Path
+        path to a configuration file in TOML format.
+        Parsed by ``toml`` library, then converted to an
+        instance of ``vak.config.parse.Config`` by
+        calling ``vak.parse.from_toml``
+
+    Returns
+    -------
+    config : vak.config.parse.Config
+        instance of Config class, whose attributes correspond to
+        sections in a config.toml file.
+    """
+    # check config_path is a file,
+    # because if it doesn't ConfigParser will just return an "empty" instance w/out sections or options
+    toml_path = Path(toml_path)
+    if not toml_path.is_file():
+        raise FileNotFoundError(f'path not recognized as a file: {toml_path}')
+
+    try:
+        with toml_path.open('r') as fp:
+            config_toml = toml.load(fp)
+    except TomlDecodeError as e:
+        raise Exception(f'Error when parsing .toml config file: {toml_path}') from e
+
+    return from_toml(config_toml, toml_path)

--- a/src/vak/config/predict.py
+++ b/src/vak/config/predict.py
@@ -98,7 +98,8 @@ REQUIRED_PREDICT_OPTIONS = [
 ]
 
 
-def parse_predict_config(config_toml, toml_path):
+def parse_predict_config(config_toml,
+                         toml_path=None):
     """parse [PREDICT] section of config.toml file
 
     Parameters
@@ -106,7 +107,8 @@ def parse_predict_config(config_toml, toml_path):
     config_toml : dict
         containing configuration file in TOML format, already loaded by parse function
     toml_path : Path
-        path to a configuration file in TOML format (used for error messages)
+        path to a configuration file in TOML format. Default is None.
+        Used for error messages if specified.
 
     Returns
     -------
@@ -120,8 +122,15 @@ def parse_predict_config(config_toml, toml_path):
 
     for required_option in REQUIRED_PREDICT_OPTIONS:
         if required_option not in predict_section:
-            raise KeyError(
-                f"the '{required_option}' option is required but was not found in the "
-                f"PREDICT section of the config.toml file: {toml_path}"
-            )
+            if toml_path:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"PREDICT section of the config.toml file: {toml_path}"
+                )
+            else:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"PREDICT section of the toml config"
+                )
+            raise KeyError(err_msg)
     return PredictConfig(**predict_section)

--- a/src/vak/config/prep.py
+++ b/src/vak/config/prep.py
@@ -112,7 +112,7 @@ REQUIRED_PREP_OPTIONS = [
 ]
 
 
-def parse_prep_config(config_toml, config_path):
+def parse_prep_config(config_toml, toml_path):
     """parse [PREP] section of config.toml file
 
     Parameters
@@ -120,7 +120,8 @@ def parse_prep_config(config_toml, config_path):
     config_toml : dict
         containing configuration file in TOML format, already loaded by parse function
     toml_path : Path
-        path to a configuration file in TOML format (used for error messages)
+        path to a configuration file in TOML format. Default is None.
+        Used for error messages if specified.
 
     Returns
     -------
@@ -140,9 +141,16 @@ def parse_prep_config(config_toml, config_path):
 
     for required_option in REQUIRED_PREP_OPTIONS:
         if required_option not in prep_section:
-            raise KeyError(
-                f"the '{required_option}' option is required but was not found in the "
-                f"PREP section of the config.toml file: {config_path}"
-            )
+            if toml_path:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"PREP section of the config.toml file: {toml_path}"
+                )
+            else:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"PREP section of the toml config"
+                )
+            raise KeyError(err_msg)
 
     return PrepConfig(**prep_section)

--- a/src/vak/config/train.py
+++ b/src/vak/config/train.py
@@ -103,7 +103,8 @@ def parse_train_config(config_toml, toml_path):
     config_toml : dict
         containing configuration file in TOML format, already loaded by parse function
     toml_path : Path
-        path to a configuration file in TOML format (used for error messages)
+        path to a configuration file in TOML format. Default is None.
+        Used for error messages if specified.
 
     Returns
     -------
@@ -114,8 +115,15 @@ def parse_train_config(config_toml, toml_path):
     train_section = dict(train_section.items())
     for required_option in REQUIRED_TRAIN_OPTIONS:
         if required_option not in train_section:
-            raise KeyError(
-                f"the '{required_option}' option is required but was not found in the "
-                f"TRAIN section of the config.toml file: {toml_path}"
-            )
+            if toml_path:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"TRAIN section of the config.toml file: {toml_path}"
+                )
+            else:
+                err_msg = (
+                    f"the '{required_option}' option is required but was not found in the "
+                    f"TRAIN section of the toml config"
+                )
+            raise KeyError(err_msg)
     return TrainConfig(**train_section)

--- a/src/vak/config/validators.py
+++ b/src/vak/config/validators.py
@@ -71,24 +71,33 @@ VALID_OPTIONS = {
 }
 
 
-def are_sections_valid(config_dict, toml_path):
+def are_sections_valid(config_dict, toml_path=None):
     sections = list(config_dict.keys())
     MODEL_NAMES = [model_name for model_name, model_builder in models.find()]
     # add model names to valid sections so users can define model config in sections
     valid_sections = VALID_SECTIONS + MODEL_NAMES
     for section in sections:
         if section not in valid_sections and f'{section}Model' not in valid_sections:
-            raise ValueError(
-                f'section defined in {toml_path} is not valid: {section}'
-            )
+            if toml_path:
+                err_msg = f'section defined in {toml_path} is not valid: {section}'
+            else:
+                err_msg = f'section defined in toml config is not valid: {section}'
+            raise ValueError(err_msg)
 
 
-def are_options_valid(config_dict, section, toml_path):
+def are_options_valid(config_dict, section, toml_path=None):
     user_options = set(config_dict[section].keys())
     valid_options = set(VALID_OPTIONS[section])
     if not user_options.issubset(valid_options):
         invalid_options = user_options - valid_options
-        raise ValueError(
-            f"the following options from {section} section in "
-            f"the config file '{toml_path.name}' are not valid:\n{invalid_options}"
+        if toml_path:
+            err_msg = (
+                f"the following options from {section} section in "
+                f"the config file '{toml_path.name}' are not valid:\n{invalid_options}"
         )
+        else:
+            err_msg = (
+                f"the following options from {section} section in "
+                f"the toml config are not valid:\n{invalid_options}"
+            )
+        raise ValueError(err_msg)


### PR DESCRIPTION
refactors `parse.from_toml` function into two functions, the original and a new `parse.from_toml_path`, as described in #305 