### PR TITLE
Make tests run on cpu and when present gpu

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -2,6 +2,7 @@ from .annot import *
 from .audio import *
 from .config import *
 from .dataframe import *
+from .device import *
 from .spect import *
 from .split import *
 from .test_data import *

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -120,6 +120,8 @@ def specific_config(generated_test_configs_root,
             that points to temporary copy of specified config,
             with any options changed as specified
         """
+        original_config_path = None
+
         for schematized_config in list_of_schematized_configs:
             if all(
                 [
@@ -130,28 +132,35 @@ def specific_config(generated_test_configs_root,
                 ]
             ):
                 original_config_path = generated_test_configs_root.joinpath(schematized_config['filename'])
-                config_copy_path = tmp_path.joinpath(original_config_path.name)
-                config_copy_path = shutil.copy(src=original_config_path,
-                                               dst=config_copy_path)
 
-                if options_to_change is not None:
-                    if isinstance(options_to_change, dict):
-                        options_to_change = [options_to_change]
-                    elif isinstance(options_to_change, list):
-                        continue
-                    else:
-                        raise TypeError(f'invalid type for `options_to_change`: {type(options_to_change)}')
+        if original_config_path is None:
+            raise ValueError(
+                f"did not find a specific config with `config_type`='{config_type}', "
+                f"`annot_format`='{annot_format}', `audio_format`='{audio_format}', "
+                f"and `config_type`='{spect_format}', "
+            )
+        config_copy_path = tmp_path.joinpath(original_config_path.name)
+        config_copy_path = shutil.copy(src=original_config_path,
+                                       dst=config_copy_path)
 
-                    with config_copy_path.open('r') as fp:
-                        config_toml = toml.load(fp)
+        if options_to_change is not None:
+            if isinstance(options_to_change, dict):
+                options_to_change = [options_to_change]
+            elif isinstance(options_to_change, list):
+                pass
+            else:
+                raise TypeError(f'invalid type for `options_to_change`: {type(options_to_change)}')
 
-                    for opt_dict in options_to_change:
-                        config_toml[opt_dict['section']][opt_dict['option']] = opt_dict['value']
+            with config_copy_path.open('r') as fp:
+                config_toml = toml.load(fp)
 
-                    with config_copy_path.open('w') as fp:
-                        toml.dump(config_toml, fp)
+            for opt_dict in options_to_change:
+                config_toml[opt_dict['section']][opt_dict['option']] = opt_dict['value']
 
-                return config_copy_path
+            with config_copy_path.open('w') as fp:
+                toml.dump(config_toml, fp)
+
+        return config_copy_path
 
     return _specific_config
 

--- a/tests/fixtures/device.py
+++ b/tests/fixtures/device.py
@@ -1,0 +1,18 @@
+import pytest
+import torch
+
+DEVICES = ['cpu']
+if torch.cuda.is_available():
+    DEVICES.append('cuda')
+
+
+@pytest.fixture(params=DEVICES)
+def device(request):
+    """parametrized device function,
+    that returns string names of the devices
+    that ``torch`` considers "available".
+
+    causes any test using ``device`` fixture to run just once
+    if only a cpu is available,
+    and twice if ``torch.cuda.is_available()`` returns ``True``."""
+    return request.param

--- a/tests/test_cli/test_eval.py
+++ b/tests/test_cli/test_eval.py
@@ -20,20 +20,26 @@ def test_eval(audio_format,
               spect_format,
               annot_format,
               specific_config,
-              tmp_path):
+              tmp_path,
+              device):
     output_dir = tmp_path.joinpath(f'test_eval_{audio_format}_{spect_format}_{annot_format}')
     output_dir.mkdir()
 
-    options_to_change = {
-        'section': 'EVAL',
-        'option': 'output_dir',
-        'value': str(output_dir)
-    }
+    options_to_change = [
+        {'section': 'EVAL',
+         'option': 'output_dir',
+         'value': str(output_dir)},
+        {'section': 'EVAL',
+         'option': 'device',
+         'value': device}
+    ]
+
     toml_path = specific_config(config_type='eval',
                                 audio_format=audio_format,
                                 annot_format=annot_format,
                                 spect_format=spect_format,
                                 options_to_change=options_to_change)
+
     cfg = vak.config.parse.from_toml_path(toml_path)
     model_config_map = vak.config.models.map_from_path(toml_path, cfg.eval.models)
 

--- a/tests/test_cli/test_learncurve.py
+++ b/tests/test_cli/test_learncurve.py
@@ -1,4 +1,5 @@
 """tests for vak.cli.learncurve module"""
+import vak.config
 import vak.constants
 import vak.cli.learncurve
 
@@ -7,15 +8,20 @@ from ..test_core.test_learncurve import learncurve_output_matches_expected
 
 
 def test_learncurve(specific_config,
-                    tmp_path):
+                    tmp_path,
+                    device):
     root_results_dir = tmp_path.joinpath('test_learncurve_root_results_dir')
     root_results_dir.mkdir()
 
-    options_to_change = {
-        'section': 'LEARNCURVE',
-        'option': 'root_results_dir',
-        'value': str(root_results_dir)
-    }
+    options_to_change = [
+        {'section': 'LEARNCURVE',
+         'option': 'root_results_dir',
+         'value': str(root_results_dir)},
+        {'section': 'LEARNCURVE',
+         'option': 'device',
+         'value': device}
+        ]
+
     toml_path = specific_config(config_type='learncurve',
                                 audio_format='cbin',
                                 annot_format='notmat',

--- a/tests/test_cli/test_predict.py
+++ b/tests/test_cli/test_predict.py
@@ -21,15 +21,20 @@ def test_predict(audio_format,
                  spect_format,
                  annot_format,
                  specific_config,
-                 tmp_path):
+                 tmp_path,
+                 device):
     output_dir = tmp_path.joinpath(f'test_predict_{audio_format}_{spect_format}_{annot_format}')
     output_dir.mkdir()
 
-    options_to_change = {
-        'section': 'PREDICT',
-        'option': 'output_dir',
-        'value': str(output_dir)
-    }
+    options_to_change = [
+        {'section': 'PREDICT',
+         'option': 'output_dir',
+         'value': str(output_dir)},
+        {'section': 'PREDICT',
+         'option': 'device',
+         'value': device}
+    ]
+
     toml_path = specific_config(config_type='predict',
                                 audio_format=audio_format,
                                 annot_format=annot_format,

--- a/tests/test_cli/test_train.py
+++ b/tests/test_cli/test_train.py
@@ -1,0 +1,58 @@
+"""tests for vak.cli.train module"""
+import pytest
+
+import vak.config
+import vak.constants
+import vak.paths
+import vak.cli.train
+
+from . import cli_asserts
+from ..test_core.test_train import train_output_matches_expected
+
+
+@pytest.mark.parametrize(
+    'audio_format, spect_format, annot_format',
+    [
+        ('cbin', None, 'notmat'),
+        ('wav', None, 'koumura'),
+        (None, 'mat', 'yarden'),
+    ]
+)
+def test_train(audio_format,
+               spect_format,
+               annot_format,
+               specific_config,
+               tmp_path,
+               device):
+    root_results_dir = tmp_path.joinpath('test_train_root_results_dir')
+    root_results_dir.mkdir()
+
+    options_to_change = [
+        {'section': 'TRAIN',
+         'option': 'root_results_dir',
+         'value': str(root_results_dir)},
+        {'section': 'TRAIN',
+         'option': 'device',
+         'value': device}
+        ]
+
+    toml_path = specific_config(config_type='train',
+                                audio_format=audio_format,
+                                annot_format=annot_format,
+                                spect_format=spect_format,
+                                options_to_change=options_to_change)
+
+    vak.cli.train(toml_path)
+
+    cfg = vak.config.parse.from_toml_path(toml_path)
+    model_config_map = vak.config.models.map_from_path(toml_path, cfg.train.models)
+    results_path = sorted(root_results_dir.glob(f'{vak.constants.RESULTS_DIR_PREFIX}*'))
+    assert len(results_path) == 1
+    results_path = results_path[0]
+
+    assert train_output_matches_expected(cfg,
+                                         model_config_map,
+                                         results_path)
+
+    assert cli_asserts.toml_config_file_copied_to_results_path(results_path, toml_path)
+    assert cli_asserts.log_file_created(command='train', output_path=results_path)

--- a/tests/test_core/test_eval.py
+++ b/tests/test_core/test_eval.py
@@ -27,15 +27,20 @@ def test_eval(audio_format,
               spect_format,
               annot_format,
               specific_config,
-              tmp_path):
+              tmp_path,
+              device):
     output_dir = tmp_path.joinpath(f'test_eval_{audio_format}_{spect_format}_{annot_format}')
     output_dir.mkdir()
 
-    options_to_change = {
-        'section': 'EVAL',
-        'option': 'output_dir',
-        'value': str(output_dir)
-    }
+    options_to_change = [
+        {'section': 'EVAL',
+         'option': 'output_dir',
+         'value': str(output_dir)},
+        {'section': 'EVAL',
+         'option': 'device',
+         'value': device}
+    ]
+
     toml_path = specific_config(config_type='eval',
                                 audio_format=audio_format,
                                 annot_format=annot_format,

--- a/tests/test_core/test_learncurve.py
+++ b/tests/test_core/test_learncurve.py
@@ -50,10 +50,19 @@ def learncurve_output_matches_expected(cfg,
 
 
 def test_learncurve(specific_config,
-                    tmp_path):
+                    tmp_path,
+                    device):
+    options_to_change = {
+        'section': 'LEARNCURVE',
+        'option': 'device',
+        'value': device
+    }
+
     toml_path = specific_config(config_type='learncurve',
                                 audio_format='cbin',
-                                annot_format='notmat')
+                                annot_format='notmat',
+                                options_to_change=options_to_change)
+
     cfg = vak.config.parse.from_toml_path(toml_path)
     model_config_map = vak.config.models.map_from_path(toml_path, cfg.learncurve.models)
     results_path = vak.paths.generate_results_dir_name_as_path(tmp_path)

--- a/tests/test_core/test_predict.py
+++ b/tests/test_core/test_predict.py
@@ -24,15 +24,20 @@ def test_predict(audio_format,
                  spect_format,
                  annot_format,
                  specific_config,
-                 tmp_path):
+                 tmp_path,
+                 device):
     output_dir = tmp_path.joinpath(f'test_predict_{audio_format}_{spect_format}_{annot_format}')
     output_dir.mkdir()
 
-    options_to_change = {
-        'section': 'PREDICT',
-        'option': 'output_dir',
-        'value': str(output_dir)
-    }
+    options_to_change = [
+        {'section': 'PREDICT',
+         'option': 'output_dir',
+         'value': str(output_dir)},
+        {'section': 'PREDICT',
+         'option': 'device',
+         'value': device}
+    ]
+
     toml_path = specific_config(config_type='predict',
                                 audio_format=audio_format,
                                 annot_format=annot_format,

--- a/tests/test_core/test_train.py
+++ b/tests/test_core/test_train.py
@@ -1,4 +1,4 @@
-"""tests for vak.core.predict module"""
+"""tests for vak.core.train module"""
 import pytest
 
 import vak.config
@@ -43,11 +43,18 @@ def test_train(audio_format,
                spect_format,
                annot_format,
                specific_config,
-               tmp_path):
+               tmp_path,
+               device):
+    options_to_change = {
+        'section': 'TRAIN',
+        'option': 'device',
+        'value': device
+    }
     toml_path = specific_config(config_type='train',
                                 audio_format=audio_format,
                                 annot_format=annot_format,
-                                spect_format=spect_format)
+                                spect_format=spect_format,
+                                options_to_change=options_to_change)
     cfg = vak.config.parse.from_toml_path(toml_path)
     model_config_map = vak.config.models.map_from_path(toml_path, cfg.train.models)
     results_path = vak.paths.generate_results_dir_name_as_path(tmp_path)


### PR DESCRIPTION
adds a `device` fixture that is parametrized, and those parameters are built up dynamically, so that when `torch.cuda.is_available` is `True`, it includes `gpu`, and otherwise just `cpu` is used

all the `test_core` and `test_cli` tests use this fixture