### PR TITLE
ENH: `vak.core.predict` can save model outputs, fix #90

### DIFF
--- a/src/vak/cli/predict.py
+++ b/src/vak/cli/predict.py
@@ -51,4 +51,5 @@ def predict(toml_path):
                  output_dir=cfg.predict.output_dir,
                  min_segment_dur=cfg.predict.min_segment_dur,
                  majority_vote=cfg.predict.majority_vote,
+                 save_net_outputs=cfg.predict.save_net_outputs,
                  logger=logger)

--- a/src/vak/config/predict.py
+++ b/src/vak/config/predict.py
@@ -57,6 +57,17 @@ class PredictConfig:
         applied if the labelmap contains an 'unlabeled' label,
         because unlabeled segments makes it possible to identify
         the labeled segments. Default is False.
+   save_net_outputs : bool
+        if True, save 'raw' outputs of neural networks
+        before they are converted to annotations. Default is False.
+        Typically the output will be "logits"
+        to which a softmax transform might be applied.
+        For each item in the dataset--each row in  the `csv_path` .csv--
+        the output will be saved in a separate file in `output_dir`,
+        with the extension `{MODEL_NAME}.output.npz`. E.g., if the input is a
+        spectrogram with `spect_path` filename `gy6or6_032312_081416.npz`,
+        and the network is `TweetyNet`, then the net output file
+        will be `gy6or6_032312_081416.tweetynet.output.npz`.
     """
     # required, external files
     checkpoint_path = attr.ib(converter=expanded_user_path,
@@ -89,6 +100,7 @@ class PredictConfig:
     output_dir = attr.ib(converter=expanded_user_path, validator=is_a_directory, default=Path(os.getcwd()))
     min_segment_dur = attr.ib(validator=validators.optional(instance_of(float)), default=None)
     majority_vote = attr.ib(validator=instance_of(bool), default=True)
+    save_net_outputs = attr.ib(validator=instance_of(bool), default=False)
 
 
 REQUIRED_PREDICT_OPTIONS = [

--- a/src/vak/config/valid.toml
+++ b/src/vak/config/valid.toml
@@ -91,3 +91,5 @@ device = 'cuda'
 spect_scaler_path = '/home/user/results_181014_194418/spect_scaler'
 min_segment_dur = 0.004
 majority_vote = false
+save_net_outputs = false
+

--- a/src/vak/constants.py
+++ b/src/vak/constants.py
@@ -33,3 +33,7 @@ STRFTIME_TIMESTAMP = '%y%m%d_%H%M%S'
 
 # ---- results, from train / learncurve ----
 RESULTS_DIR_PREFIX = 'results_'
+
+# ---- output (default) file extensions. Using the `pathlib` name "suffix" ----
+ANNOT_CSV_SUFFIX = '.annot.csv'
+NET_OUTPUT_SUFFIX = '.output.npz'


### PR DESCRIPTION
- add ANNOT_CSV_SUFFIX and NET_OUTPUT_SUFFIX to `constants`,
  to use in `vak.core.predict`
- modify core.predict so it can save net outputs, fixes #90
  - add `save_net_outputs` parameter
  - if `save_net_outputs` is True, reshape outputs from
    pred_dict returned by model, remove any padding,
    then save in a file:
    output_dir/{spect path stem}.{model name}.output.npz
- add `save_net_outputs` option to `predict` config section
- make `vak.cli.predict` pass 'save_net_outputs' argument to `core.predict`
- modify `core.predict` unit tests, to test `save_net_outputs` parameter