### PR TITLE
BUG: make `torch.load` use `map_location` parameter, fix #323

### DIFF
--- a/src/vak/core/eval.py
+++ b/src/vak/core/eval.py
@@ -138,7 +138,7 @@ def eval(csv_path,
             f'running evaluation for model: {model_name}',
             logger=logger, level='info'
         )
-        model.load(checkpoint_path)
+        model.load(checkpoint_path, device=device)
         metric_vals = model.evaluate(eval_data=val_data,
                                      device=device)
         # create a "DataFrame" with just one row which we will save as a csv;

--- a/src/vak/core/predict.py
+++ b/src/vak/core/predict.py
@@ -189,7 +189,7 @@ def predict(csv_path,
         # ---------------- do the actual predicting --------------------------------------------------------------------
         log_or_print(f'loading checkpoint for {model_name} from path: {checkpoint_path}',
                      logger=logger, level='info')
-        model.load(checkpoint_path)
+        model.load(checkpoint_path, device=device)
         log_or_print(f'running predict method of {model_name}',
                      logger=logger, level='info')
         pred_dict = model.predict(pred_data=pred_data,

--- a/src/vak/engine/model.py
+++ b/src/vak/engine/model.py
@@ -338,7 +338,7 @@ class Model:
             logger=self.logger, level='info')
         torch.save(ckpt, ckpt_path)
 
-    def load(self, ckpt_path):
+    def load(self, ckpt_path, device=None):
         """load model state dict from a checkpoint file.
 
         Loads state_dicts into network and optimizer
@@ -350,10 +350,13 @@ class Model:
         ckpt_path : str, Path
             path including filename from which to load checkpoint
         """
+        if device is None:
+            device = get_default_device()
+
         log_or_print(
             f'Loading checkpoint from:\n{ckpt_path} ',
             logger=self.logger, level='info')
-        ckpt = torch.load(ckpt_path)
+        ckpt = torch.load(ckpt_path, map_location=device)
         self.network.load_state_dict(ckpt['network_state_dict'])
         self.optimizer.load_state_dict(ckpt['optimizer_state_dict'])
 

--- a/tests/test_core/test_learncurve.py
+++ b/tests/test_core/test_learncurve.py
@@ -97,15 +97,24 @@ def test_learncurve(specific_config,
 
 
 def test_learncurve_no_results_path(specific_config,
-                                    tmp_path):
+                                    tmp_path,
+                                    device):
     root_results_dir = tmp_path.joinpath('test_learncurve_no_results_path')
     root_results_dir.mkdir()
 
-    options_to_change = {
-        'section': 'LEARNCURVE',
-        'option': 'root_results_dir',
-        'value': str(root_results_dir)
-    }
+    options_to_change = [
+        {
+            'section': 'LEARNCURVE',
+            'option': 'root_results_dir',
+            'value': str(root_results_dir)
+        },
+        {
+            'section': 'LEARNCURVE',
+            'option': 'device',
+            'value': device
+        }
+    ]
+
     toml_path = specific_config(config_type='learncurve',
                                 audio_format='cbin',
                                 annot_format='notmat',


### PR DESCRIPTION
- add `device` parameter to `model.load` method, defaults to None
  + if None, assign returned value of `get_default_device`
- in `load` method, pass `device` as argument for `map_location`
  when calling `torch.load`
  + this should fix bug in #323 where checkpoints trained on GPU
    are loaded onto CPU by default, causing RuntimeError
- have both `core.eval` and `core.predict` functions pass in
  the `device` they were called with, when they call `model.load`.
  This should ensure device passed by config is used.