### PR TITLE
fix how `train_dur_csv_paths.from_dir` orders replicates, fixes #340

### DIFF
--- a/src/vak/core/learncurve/learncurve.py
+++ b/src/vak/core/learncurve/learncurve.py
@@ -225,6 +225,7 @@ def learning_curve(model_config_map,
         )
 
         for replicate_num, this_train_dur_this_replicate_csv_path in enumerate(csv_paths):
+            replicate_num += 1  # so log statements below match replicate nums returned by train_dur_csv_paths
             log_or_print(
                 f'Training replicate {replicate_num} '
                 f'using dataset from .csv file: {this_train_dur_this_replicate_csv_path}',

--- a/tests/test_core/test_train_dur_csv_paths.py
+++ b/tests/test_core/test_train_dur_csv_paths.py
@@ -1,0 +1,205 @@
+import tempfile
+
+import pandas as pd
+import pytest
+
+import vak.converters
+import vak.core.learncurve.train_dur_csv_paths
+import vak.csv
+import vak.io.dataframe
+import vak.labels
+import vak.paths
+
+SPECT_KEY = 's'
+TIMEBINS_KEY = 't'
+
+
+@pytest.fixture
+def tmp_previous_run_path_factory(tmp_path):
+
+    def _tmp_previous_run_path(train_set_durs,
+                               num_replicates,
+                               dataset_csv_path_filename='fake_data_prep.csv'):
+        results_path = vak.paths.generate_results_dir_name_as_path(tmp_path)
+        results_path.mkdir()
+        csv_path = tmp_path.joinpath('data_dir').joinpath(dataset_csv_path_filename)
+
+        for train_set_dur in train_set_durs:
+            path_this_train_dur = results_path.joinpath(
+                vak.core.learncurve.train_dur_csv_paths.train_dur_dirname(train_set_dur)
+            )
+            path_this_train_dur.mkdir()
+            for replicate_num in range(1, num_replicates + 1):
+                path_this_replicate = path_this_train_dur.joinpath(
+                    vak.core.learncurve.train_dur_csv_paths.replicate_dirname(replicate_num)
+                )
+                path_this_replicate.mkdir()
+                fake_subset_csv_path = path_this_replicate.joinpath(
+                    vak.core.learncurve.train_dur_csv_paths.subset_csv_filename(
+                        csv_path, train_set_dur, replicate_num
+                    )
+                )
+                # make fake subset csv path exist
+                with fake_subset_csv_path.open('w') as fp:
+                    fp.write('')
+                assert fake_subset_csv_path.exists()
+
+        return results_path
+
+    return _tmp_previous_run_path
+
+
+@pytest.mark.parametrize(
+    'train_set_durs, num_replicates',
+    [
+        ([4, 6], 2),
+        ([30, 45, 60, 120, 180], 10),
+    ]
+)
+def test_dict_from_dir(tmp_previous_run_path_factory,
+                       train_set_durs,
+                       num_replicates):
+    """note: this test specifically tests that
+    csv paths are sorted numerically by replicate number,
+    not alphabetically.
+    See https://github.com/NickleDave/vak/issues/340
+
+    this is the main reason for factoring out the helper function ``_dict_from_dir``
+    """
+    previous_run_path = tmp_previous_run_path_factory(train_set_durs, num_replicates)
+
+    train_dur_csv_paths = vak.core.learncurve.train_dur_csv_paths._dict_from_dir(previous_run_path)
+
+    assert isinstance(train_dur_csv_paths, dict)
+    assert sorted(train_dur_csv_paths.keys()) == train_set_durs
+    for train_set_dur, csv_list in train_dur_csv_paths.items():
+        replicate_nums = [int(csv.parent.name.split('_')[-1]) for csv in csv_list]
+        assert replicate_nums == list(range(1, num_replicates + 1))
+
+
+@pytest.mark.parametrize(
+    'window_size',
+    [44, 88, 176]
+)
+def test_from_dir(specific_config,
+                  labelset_notmat,
+                  tmp_path,
+                  default_model,
+                  device,
+                  previous_run_path_factory,
+                  window_size):
+    root_results_dir = tmp_path.joinpath('tmp_root_results_dir')
+    root_results_dir.mkdir()
+
+    options_to_change = [
+        {'section': 'LEARNCURVE',
+         'option': 'root_results_dir',
+         'value': str(root_results_dir)},
+        {'section': 'LEARNCURVE',
+         'option': 'device',
+         'value': device},
+        {'section': 'LEARNCURVE',
+         'option': 'previous_run_path',
+         'value': str(previous_run_path_factory(default_model))},
+        {'section': 'DATALOADER',
+         'option': 'window_size',
+         'value': window_size}
+    ]
+    toml_path = specific_config(config_type='learncurve',
+                                model=default_model,
+                                audio_format='cbin',
+                                annot_format='notmat',
+                                options_to_change=options_to_change)
+    cfg = vak.config.parse.from_toml_path(toml_path)
+
+    csv_path = cfg.learncurve.csv_path
+    dataset_df = pd.read_csv(csv_path)
+    timebin_dur = vak.io.dataframe.validate_and_get_timebin_dur(dataset_df)
+
+    labelset_notmat = vak.converters.labelset_to_set(labelset_notmat)
+    has_unlabeled = vak.csv.has_unlabeled(csv_path, labelset_notmat, TIMEBINS_KEY)
+    if has_unlabeled:
+        map_unlabeled = True
+    else:
+        map_unlabeled = False
+    labelmap = vak.labels.to_map(labelset_notmat, map_unlabeled=map_unlabeled)
+
+    results_path = tmp_path.joinpath('test_from_dir')
+    results_path.mkdir()
+
+    previous_run_path = previous_run_path_factory(default_model)
+    previous_run_path = vak.converters.expanded_user_path(previous_run_path)
+
+    train_dur_csv_paths = vak.core.learncurve.train_dur_csv_paths.from_dir(previous_run_path,
+                                                                           cfg.learncurve.train_set_durs,
+                                                                           timebin_dur,
+                                                                           cfg.learncurve.num_replicates,
+                                                                           results_path,
+                                                                           window_size,
+                                                                           SPECT_KEY,
+                                                                           TIMEBINS_KEY,
+                                                                           labelmap)
+    assert isinstance(train_dur_csv_paths, dict)
+    assert sorted(train_dur_csv_paths.keys()) == sorted(cfg.learncurve.train_set_durs)
+    for train_set_dur, csv_list in train_dur_csv_paths.items():
+        replicate_nums = [int(csv.parent.name.split('_')[-1]) for csv in csv_list]
+        assert replicate_nums == list(range(1, cfg.learncurve.num_replicates + 1))
+
+
+@pytest.mark.parametrize(
+    'window_size',
+    [44, 88, 176]
+)
+def test_from_df(specific_config,
+                 labelset_notmat,
+                 default_model,
+                 device,
+                 tmp_path,
+                 window_size):
+    root_results_dir = tmp_path.joinpath('tmp_root_results_dir')
+    root_results_dir.mkdir()
+
+    options_to_change = [
+        {'section': 'LEARNCURVE',
+         'option': 'root_results_dir',
+         'value': str(root_results_dir)},
+        {'section': 'LEARNCURVE',
+         'option': 'device',
+         'value': device},
+        {'section': 'DATALOADER',
+         'option': 'window_size',
+         'value': window_size}
+    ]
+    toml_path = specific_config(config_type='learncurve',
+                                model=default_model,
+                                audio_format='cbin',
+                                annot_format='notmat',
+                                options_to_change=options_to_change)
+    cfg = vak.config.parse.from_toml_path(toml_path)
+
+    csv_path = cfg.learncurve.csv_path
+    dataset_df = pd.read_csv(csv_path)
+    timebin_dur = vak.io.dataframe.validate_and_get_timebin_dur(dataset_df)
+
+    labelset_notmat = vak.converters.labelset_to_set(labelset_notmat)
+    has_unlabeled = vak.csv.has_unlabeled(csv_path, labelset_notmat, TIMEBINS_KEY)
+    if has_unlabeled:
+        map_unlabeled = True
+    else:
+        map_unlabeled = False
+    labelmap = vak.labels.to_map(labelset_notmat, map_unlabeled=map_unlabeled)
+
+    results_path = tmp_path.joinpath('test_from_df')
+    results_path.mkdir()
+
+    train_dur_csv_paths = vak.core.learncurve.train_dur_csv_paths.from_df(dataset_df,
+                                                                          csv_path,
+                                                                          cfg.learncurve.train_set_durs,
+                                                                          timebin_dur,
+                                                                          cfg.learncurve.num_replicates,
+                                                                          results_path,
+                                                                          labelmap,
+                                                                          window_size,
+                                                                          SPECT_KEY,
+                                                                          TIMEBINS_KEY,
+                                                                          labelmap)


### PR DESCRIPTION
BUG: fix how `train_dur_csv_paths.from_dir` orders replicates, fixes #340
    
- refactor `train_dur_csv_paths`
  - factor out code from `train_dur_csv_paths.from_dir`
    that uses `previous_run_path` to build
    dictionary mapping training set durations to
    dataset csv paths into function `_dict_from_dir`
    + this makes it possible to unit test this function alone
    + to make sure we address https://github.com/NickleDave/vak/issues/330
  - factor out functions from `train_dur_csv_paths.from_df`
    that specify names for:
    + `train_dur` directories -- these are made within the
      results path directory, one for each specified training
      set duration
    + `replicate` directories, made within each `train_dur` directory
    + `subset` .csv filename, one for each replicate
    + this allows us to make expected names explicit +
      test they get used and use these in fixtures

- add tests/test_core/test_train_dur_csv_paths.py
  including tests for `_dict_from_dir` function
  that specifically tests whether issues in https://github.com/NickleDave/vak/issues/330 are fixed
  + to do so, create a `tmp_previous_run_path_factory` fixture
    that uses "directory/file naming" functions that
    were factored out of `train_dur_csv_paths.from_dfr`
  + this lets us create a temporary "previous run" with enough
    (fake) replicates to make sure we get numeric ordering
    (1, 2, ..., 9, 10) instead of alphabetical ordering
    (1, 10, 2, ...)