### PR TITLE
shrink data for testing, fix #349 and #341

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ SOURCE_TEST_DATA_TAR=${DATA_FOR_TESTS_DIR}source/source_test_data.tar.gz
 GENERATED_TEST_DATA_CI_TAR=${GENERATED_TEST_DATA_DIR}generated_test_data.ci.tar.gz
 GENERATED_TEST_DATA_ALL_TAR=${GENERATED_TEST_DATA_DIR}generated_test_data.tar.gz
 
-SOURCE_TEST_DATA_URL=https://osf.io/s85vh/download
-GENERATED_TEST_DATA_ALL_URL=https://osf.io/gt5xw/download
-GENERATED_TEST_DATA_CI_URL=https://osf.io/u64nt/download
+SOURCE_TEST_DATA_URL=https://osf.io/thvaw/download
+GENERATED_TEST_DATA_ALL_URL=https://osf.io/maf7e/download
+GENERATED_TEST_DATA_CI_URL=https://osf.io/z5mk6/download
 
 help:
 	@echo 'Makefile for vak                                                           			'


### PR DESCRIPTION
- update urls for data for testing, to point at re-generated .tar.gz files

There were two main reasons that the .tar.gz files were too big
+ one was a bunch of generated spectrograms that had just been left in the source directory
+ the other was actual source data that takes up a lot of space e.g. the Cassin's Vireo audio files that are barely even being used

I think I discussed the latter on one of the issues this closes, but not the former? So commenting here