### PR TITLE
BUG: handle predicted annotations with no segments, fix #393

### DIFF
--- a/src/vak/core/predict.py
+++ b/src/vak/core/predict.py
@@ -265,6 +265,10 @@ def predict(
                 min_segment_dur=min_segment_dur,
                 majority_vote=majority_vote,
             )
+            if labels is None and onsets_s is None and offsets_s is None:
+                # handle the case when all time bins are predicted to be unlabeled
+                # see https://github.com/NickleDave/vak/issues/383
+                continue
             seq = crowsetta.Sequence.from_keyword(
                 labels=labels, onsets_s=onsets_s, offsets_s=offsets_s
             )


### PR DESCRIPTION
See rationale for this fix on that issue:
https://github.com/NickleDave/vak/issues/393
and related bug report in
https://github.com/NickleDave/vak/issues/386

- change `lbl_tb2segments` to return all `None`s
  when `lbl_tb` passed in is all 'unlabeled' class
- also add logic to `lbl_tb2segment` to handle case
  where post-processing removes all labeled segments;
  in that case again return all `None`s
- change `vak.core.predict` so it just `continue`s
  when `lbl_tb2segments` returns all `None`s
  + i.e. do not create an `Annotation` instance for the vocalization