### PR TITLE
DOC: add nav entries back to sidebar, fix #426 [skip ci]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'vak'
-copyright = '2018, David Nicholson, Yarden Cohen'
+copyright = '2017-present, David Nicholson, Yarden Cohen'
 author = 'David Nicholson, Yarden Cohen'
 
 # The short X.Y version
@@ -88,7 +88,9 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'sidebar_includehidden': 'true'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,3 +41,11 @@ please consult the :ref:`reference`.
 :ref:`about`
 ------------
 For more about the goals of ``vak`` and its development, please see :ref:`about`.
+
+.. toctree::
+   :hidden:
+
+   get_started/get_started
+   howto/howto
+   reference/reference
+   reference/about


### PR DESCRIPTION
- include hidden toctrees in sidebar

  change theme settings in conf.py.
  Theme is supposed to have this option
  set to 'true' by default,
  but I found I needed to change it,
  not sure why.

- add hidden toctree to bottom of doc/index.rst

  had removed toctree before and instead link to key
  sections with brief written explanations

- fix copyright date in doc/conf.py

  Clean-up, not really related to this issue

DOC: