### PR TITLE
DOC: add CoC and contributing, fix #8 #56 [skip ci]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing Guidelines
+
+:tada: **First off, thank you for considering contributing to our project!** :tada:
+
+This is a community-driven project, so it's people like you that make it useful and
+successful.
+These are some of the many ways to contribute:
+
+* :bug: Submitting bug reports and feature requests
+* :memo: Writing tutorials or examples
+* :mag: Fixing typos and improving the documentation
+* :bulb: Writing code for everyone to use
+* :people_holding_hands: Community engagement and outreach
+
+If you get stuck at any point you can create an
+[issue](https://github.com/NickleDave/vak/issues) on GitHub or contact
+us at one of the channels mentioned in the
+ [Contributing Guide](https://vak.readthedocs.io/en/latest/development/index.html)
+
+For more information on contributing to open source projects,
+[GitHub's own guide](https://opensource.guide/how-to-contribute)
+is a great starting point if you are new to version control.
+Also, checkout the
+[Zen of Scientific Software Maintenance](https://jrleeman.github.io/ScientificSoftwareMaintenance/)
+for some guiding principles on how to create high quality scientific software
+contributions.
+
+## Ground Rules
+
+The goal is to maintain a diverse community that's pleasant for everyone.
+**Please be considerate and respectful of others**.
+Everyone must abide by our [Code of Conduct](../CODE_OF_CONDUCT.md) and we encourage all to
+read it carefully.
+
+## Quick links
+
+* [Ways to Contribute](https://vak.readthedocs.io/en/latest/development/contributors.html#ways-to-contribute)
+* [Getting Help](https://vak.readthedocs.io/en/latest/development/contributors.html#getting-help)
+* [Providing Feedback](https://vak.readthedocs.io/en/latest/development/contributors.html#providing-feedback)
+* [Contributing Code](https://vak.readthedocs.io/en/latest/development/contributors.html#contributing-code)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting 
+[David Nicholson](https://nicholdav.info/) (email: nicholdav at gmail dot com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/doc/development/commit-abbreviations.rst
+++ b/doc/development/commit-abbreviations.rst
@@ -1,0 +1,14 @@
+.. code-block:: console
+
+   API: an (incompatible) API change
+   BUG: bug fix
+   DEP: deprecate something, or remove a deprecated object
+   DEV: development tool or utility
+   DOC: documentation
+   ENH: enhancement
+   CLN: maintenance commit (refactoring, typos, etc.)
+   REV: revert an earlier commit
+   STY: style fix (whitespace, PEP8)
+   TST: addition or modification of tests
+   TYP: static typing
+   REL: related to releasing ``vak``

--- a/doc/development/contributors.rst
+++ b/doc/development/contributors.rst
@@ -1,0 +1,261 @@
+.. _contributing:
+
+==================
+Contributors Guide
+==================
+
+Ways to Contribute
+==================
+
+Ways to Contribute Documentation and/or Code
+--------------------------------------------
+
+* Tackle any issue that you wish! Some issues are labeled as **"good first issues"** to
+  indicate that they are beginner friendly, meaning that they don't require extensive
+  knowledge of the project.
+* Make a tutorial or gallery example of how to do something.
+* Improve the API documentation.
+* Contribute code! This can be code that you already have and it doesn't need to be
+  perfect! We will help you clean things up, test it, etc.
+
+Ways to Contribute Feedback
+---------------------------
+
+* Provide feedback about how we can improve the project or about your particular use
+  case. Open an `issue <https://github.com/NickleDave/vakt/issues>`_ with
+  feature requests or bug fixes.
+* Help triage issues, or give a "thumbs up" on issues that others reported which are
+  relevant to you (using the
+  `"Add Your Reaction" icon <https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/>`_).
+
+Ways to Contribute to Community Building
+----------------------------------------
+
+* Cite ``vak`` when using the project.
+  Please see `the CITATION.cff <https://github.com/NickleDave/vak/blob/main/CITATION.cff>`_ file for details.
+  To obtain a citation in APA or BibTEX format, click on "Cite this repository" on the
+  `GitHub repository <https://github.com/NickleDave/vak>`_.
+* Spread the word about ``vak`` and star the project on GitHub!
+
+Providing Feedback
+==================
+
+Two of the main ways to contribute are to report a bug or to request a feature.
+Both can be done by opening an `Issue <https://github.com/NickleDave/vak/issues>`_
+on GitHub and filling out the template.
+
+* Find the `Issues <https://github.com/NickleDave/vak/issues>`_ tab on the
+  top of the GitHub repository and click *New Issue*.
+* Choose a template based on the type of feedback
+
+  * For a bug report, click on *Get started* next to *Bug report*.
+
+  * For a feature request, click on *Get started* next to *Feature request*.
+
+* **Please try to fill out the template with as much detail as you can**.
+* After submitting your bug report or feature request,
+  try to answer any follow up questions as best as you can.
+
+General Guidelines
+==================
+
+.. _getting-help:
+
+Getting Help
+------------
+
+Discussion often happens on GitHub issues and pull requests. In addition, there is a
+`Discourse forum <https://forum.vocles.org/>`_ for
+the project where you can ask questions.
+
+.. _dev-workflow:
+
+Workflow for Contributing
+-------------------------
+
+We follow the `GitHub pull request workflow <http://www.asmeurer.com/git-workflow>`_
+to make changes to our codebase. Every change made goes through a pull request, even
+our own, so that our
+`continuous integration <https://the-turing-way.netlify.app/reproducible-research/ci.html>`_
+services have a chance to check that the code is up to standards and passes all
+our tests. This way, the *main* branch is always stable.
+
+For New Contributors
+####################
+
+Please take a look at these resources to learn about Git and pull requests:
+
+* `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`_.
+* `Git Workflow Tutorial <http://www.asmeurer.com/git-workflow/>`_ by Aaron Meurer.
+* `How to Contribute to an Open Source Project on GitHub <https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github>`_.
+
+And please don't hesitate to :ref:`ask questions <getting-help>`.
+
+
+Writing commit messages
+#######################
+
+We follow the convention of beginning a ``git`` commit message
+with an abbreviation that indicates the reason for the commit.
+This convention is used by several Python data science libraries.
+The standard abbreviations we use to start the commit message with are
+
+    .. include:: commit-abbreviations.rst
+
+.. _dev-env:
+
+Setting up a development environment
+====================================
+
+This section describes how to set up an environment for development.
+This is the steps the maintainers follow, and it can also be used by contributors.
+
+You will need:
+~~~~~~~~~~~~~~
+1. the version control tool ``git``
+  (you can install ``git`` from `Github <https://help.github.com/en/github/getting-started-with-github/set-up-git>`_,
+  with your operating system package manager, or using ``conda``.)
+2. ``make`` (installed by default on most Unix systems, not available on Windows)
+  Here is an introduction to ``make`` from the Turing Way:
+  https://the-turing-way.netlify.app/reproducible-research/reproducible-research.html
+
+Steps
+~~~~~
+
+.. contents::
+   :local:
+
+1. Clone the repository
+#######################
+
+Clone the repository from Github using ``git``
+
+.. code-block:: console
+
+    you@your-computer: ~/Documents $ git clone https://github.com/NickleDave/vak
+
+2. Create a virtual environment
+###############################
+
+The repository includes a Makefile that automates setting up a development environment.
+
+To create a virtual environment, run the following:
+
+.. code-block:: console
+
+   make venv
+
+You can then activate the virtual environment by executing:
+
+.. code-block:: console
+
+   . ./.venv/activate
+
+on MacOS and Linux, or
+
+.. code-block:: console
+
+   ./.venv/activate.bat
+
+on Windows.
+
+3. Download test data
+######################
+
+There are three types of data of needed for tests.
+
+1. **``.toml`` configuration files.**  These are under version control,
+so you will already have them when you clone the repository
+
+The other two types of data are made up of files
+that are too large to keep in a GitHub repository.
+Instead, the files are kept on a public
+`Open Science Framework <https://osf.io>`_ project, here:
+https://osf.io/vz48c/
+
+There are commands in the Makefile that download this data.
+
+The two other types of data for tests are:
+
+2. "source" data, that consists of files used as input to ``vak``
+such as audio and annotation files. These files are less likely to change
+as ``vak`` develops, so they are kept separate.
+
+To download these files, run:
+
+.. code-block:: console
+
+   make test-data-download-source
+
+3. "generated" data, that consists of files created by ``vak``,
+such as .csv files that represent datasets, and the saved neural network
+checkpoints.
+
+These files are generated by a script: ``./tests/scripts/generate_data_for_tests.py``.
+Generally speaking, the core maintainers are the only ones that should need
+to run this script.
+
+To download these files, run:
+
+.. code-block:: console
+
+   make test-data-download-generated
+
+4. Proceed with development
+###########################
+
+After completing these steps, you are ready for development!
+
+Contributing Code
+=================
+
+``vak`` Code Overview
+---------------------
+
+The source code for ``vak`` is located in the directory ``./src/vak``. When contributing
+code, be sure to follow the general guidelines in the
+:ref:`dev-workflow` section.
+
+Code Style
+----------
+
+In general, ``vak`` code should
+
+* follow the `Zen of Python <https://www.python.org/dev/peps/pep-0020/#id2>`_ in terms of implementation
+* follow the `PEP8 style guide <https://www.python.org/dev/peps/pep-0008/>`_ for code
+* follow the `numpy standard for docstrings <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
+
+We also use the tool `Black <https://github.com/psf/black>`_ to format the code, so we don't have to think about it.
+
+Testing your Code
+-----------------
+
+Automated testing helps ensure that our code is as free of bugs as it can be.
+It also lets us know immediately if a change we make breaks any other part of the code.
+
+All of our test code and data are stored in the directory ``./tests``,
+that is set up as if it were a Python package.
+We use the `pytest <https://pytest.org>`_ framework to run the test suite.
+To run the entire test suite, run ``pytest`` from the command line:
+
+.. code-block:: console
+
+   $ pytest
+
+You can also run tests in just one test script using:
+
+.. code-block:: console
+
+   $ pytest ./tests/NAME_OF_TEST_FILE.py
+
+Please write tests for your code so that we can be sure that it won't break any of the
+existing functionality.
+Tests also help us be confident that we won't break your code in the future.
+
+If you're **new to testing**, see existing test files for examples of things to do.
+**Don't let the tests keep you from submitting your contribution!**
+If you're not sure how to do this or are having trouble, submit your pull request
+anyway.
+We will help you create the tests and sort out any kind of problem during code review.
+It's OK if you can't or don't know how to test something.
+Leave a comment in the pull request and we'll help you out.

--- a/doc/development/index.rst
+++ b/doc/development/index.rst
@@ -1,0 +1,30 @@
+.. _devindex:
+
+===========
+Development
+===========
+
+Contributing to ``vak``
+=======================
+
+This is a community driven project and everyone is welcome to contribute.
+
+The project is hosted at the
+`vak GitHub repository <https://github.com/NickleDave/vak>`_.
+
+The goal is to maintain a diverse community that's pleasant for everyone.
+**Please be considerate and respectful of others**. Everyone must abide by our
+`Code of Conduct <https://github.com/NickleDave/vak/blob/main/CODE_OF_CONDUCT.md>`_
+and we encourage all to read it carefully.
+
+.. toctree::
+   :maxdepth: 2
+
+   contributors
+
+This development documentation is adapted from the exemplary guides provided by
+`numpy <https://numpy.org>`_, `pandas <https://pandas.pydata.org>`_,
+and `PyGMT <https://www.pygmt.org>`_.
+``vak`` is built on ``numpy`` and ``pandas`` (among other libraries) ---
+please cite them also if you use ``vak`` in your own work,
+and consider contributing to their development.

--- a/doc/discussion/discussion.rst
+++ b/doc/discussion/discussion.rst
@@ -1,8 +1,0 @@
-Explanations
-============
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-   Explanations

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,6 +38,10 @@ please check in the :ref:`howto_index`.
 If you need to look up information about the command-line interface, configuration files, etc.,
 please consult the :ref:`reference_index`.
 
+:ref:`devindex`
+------------------
+To learn about development of ``vak`` and how you can contribute, please see :ref:`devindex`
+
 :ref:`about`
 ------------
 For more about the goals of ``vak`` and its development, please see :ref:`about`.
@@ -48,9 +52,11 @@ Not enough open-source research software libraries have poems. We do, here: :ref
 
 .. toctree::
    :hidden:
+   :maxdepth: 1
 
    get_started/index
    howto/index
    reference/index
+   development/index
    reference/about
    poems/index


### PR DESCRIPTION
- add CODE_OF_CONDUCT.md
- remove doc/discussion/discussion.rst, unused
- add development/commit-abbreviations.rst
- add development/contributors.rst, fixes #8 #56
- add doc/development/index.rst
- link to development docs in doc/index.rst
- add .github/CONTRIBUTING.md with links to docs