### PR TITLE
DOC: make readthedocs config install libsndfile, fix #457 [skip ci]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ version: 2
 
 build:
   os: ubuntu-20.04
+  apt_packages:
+    - libsndfile1
   tools:
     python: "3.8"
 


### PR DESCRIPTION
Add 'apt_packages' option in 'build' section of .readthedocs.yaml that specifies to install 'libsndfile1'. This should prevent error in #457 during build on readthedocs.