### PR TITLE
Fix audio formats [skip ci]

### DIFF
--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -33,15 +33,15 @@ Before going through this tutorial, you'll need to:
    or [notepad++](https://notepad-plus-plus.org/)
 3. download example data (from this dataset: <https://figshare.com/articles/Bengalese_Finch_song_repository/4805749> )
 
-> - one day of birdsong, for
->   {download}`training data (click to download) <https://ndownloader.figshare.com/files/9537229>`
-> - another day, for
->   {download}`prediction data (click to download) <https://ndownloader.figshare.com/files/9537232>`
-> - Be sure to extract the files from these archives!
->   On Windows you can use programs like [WinRAR](https://www.rarlab.com/)
->   or [WinZIP](https://www.winzip.com/win/en/tar-gz-file.html),
->   on mac you can double click the `.tar.gz` file, and on
->   (Ubuntu) linux you can right-click and select the `Extract to` option.
+   - one day of birdsong, for training data (click to download)  
+     {download}`https://ndownloader.figshare.com/files/9537229`
+   - another day, to use to predict annnotations (click to download)
+     {download}`https://ndownloader.figshare.com/files/9537232`
+   - Be sure to extract the files from these archives!
+     On Windows you can use programs like [WinRAR](https://www.rarlab.com/)
+     or [WinZIP](https://www.winzip.com/win/en/tar-gz-file.html),
+     on mac you can double click the `.tar.gz` file, and on
+     (Ubuntu) linux you can right-click and select the `Extract to` option.
 
 4. download the corresponding configuration files (click to download):
    {download}`gy6or6_train.toml <../toml/gy6or6_train.toml>`

--- a/doc/get_started/autoannotate.md
+++ b/doc/get_started/autoannotate.md
@@ -47,6 +47,13 @@ Before going through this tutorial, you'll need to:
    {download}`gy6or6_train.toml <../toml/gy6or6_train.toml>`
    and {download}`gy6or6_predict.toml <../toml/gy6or6_predict.toml>`
 
+:::{note}
+This tutorial uses audio files in a `.cbin` format. 
+The `vak` library can load common audio formats (WAV, FLAC, OGG).
+If you are wondering about the `.cbin` format, 
+please see <https://github.com/NickleDave/evfuncs>.
+:::
+
 ## Overview
 
 There are four steps to using `vak` to automate annotating vocalizations

--- a/src/vak/constants.py
+++ b/src/vak/constants.py
@@ -10,7 +10,12 @@ from scipy.io import loadmat
 import soundfile
 
 
-AUDIO_FORMAT_FUNC_MAP = {"cbin": load_cbin, "wav": soundfile.read}
+AUDIO_FORMAT_FUNC_MAP = {
+    "cbin": load_cbin,
+    "flac": soundfile.read,
+    "ogg": soundfile.read,
+    "wav": soundfile.read,
+}
 
 VALID_AUDIO_FORMATS = list(AUDIO_FORMAT_FUNC_MAP.keys())
 


### PR DESCRIPTION
* adds ability to use two other audio formats (FLAC, OGG)
* revises the "getting started" tutorial to make it clearer that `vak` can work with common audio formats